### PR TITLE
Docker headless

### DIFF
--- a/docker/aarch64_headless/Dockerfile
+++ b/docker/aarch64_headless/Dockerfile
@@ -1,0 +1,115 @@
+FROM ubuntu:focal-20221130
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+RUN apt-get update -q && \
+    apt-get upgrade -yq && \
+    apt-get install -yq wget curl git build-essential vim sudo libssl-dev
+
+# lsb-release locales bash-completion tzdata gosu && \
+# RUN rm -rf /var/lib/apt/lists/*
+
+# clang
+RUN apt install -y -q libclang-dev
+
+# sdl
+RUN apt update -y && \
+    apt upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive && \
+    apt install -y -q --no-install-recommends \
+        libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev \
+        libsdl-dev libsdl-image1.2-dev
+
+# zip
+RUN apt install -y zip
+
+# swig
+RUN apt install -y swig
+
+# python
+RUN apt install -y python3.8 python3.8-dev python3.8-distutils python3.8-venv python3-pip
+
+# cmake
+RUN apt install -y cmake
+
+# headers required for building libtorch
+RUN apt install -y libgoogle-glog-dev libgflags-dev
+
+# llvm, mesa for robosuite
+RUN apt install -y llvm libosmesa6-dev
+
+# Used for Mujoco
+RUN apt install -y patchelf libglfw3 libglfw3-dev
+
+# Cleanup
+RUN rm -rf /var/lib/apt/lists/*
+
+# COPY test_mujoco_py.py /test_mujoco_py.py
+# RUN chmod 777 /test_mujoco_py.py
+
+# Add user
+RUN useradd --create-home --home-dir /home/ubuntu --shell /bin/bash --user-group --groups adm,sudo ubuntu && \
+    echo ubuntu:ubuntu | chpasswd && \
+    echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# User settings
+USER ubuntu
+
+# rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# python
+RUN pip3 install --upgrade pip
+RUN pip3 install pyyaml typing-extensions
+RUN pip3 install torch==1.12.0
+RUN pip3 install ipython jupyterlab
+RUN pip3 install numpy==1.21.3
+# RUN pip3 install gym[box2d]==0.25.1
+RUN pip3 install gym[box2d]==0.17.1
+RUN pip3 install robosuite==1.3.2
+RUN pip3 install -U 'mujoco-py<2.2,>=2.1'
+
+# # border
+# RUN cd $HOME && git clone https://github.com/taku-y/border.git
+RUN cd $HOME && mkdir -p .border/model
+
+# # Mujoco aarch64 binary
+# RUN cd $HOME && \
+#     mkdir .mujoco && \
+#     cd .mujoco && \
+#     wget https://github.com/deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-aarch64.tar.gz
+# RUN cd $HOME/.mujoco && \
+#     tar zxf mujoco-2.1.1-linux-aarch64.tar.gz && \
+#     mkdir -p mujoco210/bin && \
+#     ln -sf $PWD/mujoco-2.1.1/lib/libmujoco.so.2.1.1 $PWD/mujoco210/bin/libmujoco210.so && \
+#     ln -sf $PWD/mujoco-2.1.1/lib/libglewosmesa.so $PWD/mujoco210/bin/libglewosmesa.so && \
+#     ln -sf $PWD/mujoco-2.1.1/include/ $PWD/mujoco210/include && \
+#     ln -sf $PWD/mujoco-2.1.1/model/ $PWD/mujoco210/model
+# RUN cp /test_mujoco_py.py $HOME
+
+# PyBulletGym
+# RUN pip3 install pybullet==3.2.5
+RUN pip3 install pybullet==2.7.1
+RUN cd $HOME && \
+    git clone https://github.com/benelot/pybullet-gym.git && \
+    cd pybullet-gym && \
+    git checkout -b tmp 79396fccc1d0e170a092b50137148da48ee2edab && \
+    pip install -e .
+
+# Env vars
+# RUN echo 'export LIBTORCH=$HOME/.local/lib/python3.8/site-packages/torch' >> ~/.bashrc
+# RUN echo 'export LD_LIBRARY_PATH=$LIBTORCH/lib' >> ~/.bashrc
+RUN echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.bashrc
+# RUN echo 'export PYTHONPATH=$HOME/border/border-py-gym-env/examples:$PYTHONPATH' >> ~/.bashrc
+# RUN echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.mujoco/mujoco210/bin' >> ~/.bashrc
+
+ENV LIBTORCH_CXX11_ABI 0
+ENV LIBTORCH /home/ubuntu/.local/lib/python3.8/site-packages/torch
+ENV LD_LIBRARY_PATH $LIBTORCH/lib
+ENV PYTHONPATH /home/ubuntu/border/border-py-gym-env/examples:$PYTHONPATH
+
+WORKDIR /home/ubuntu/border
+
+# ENV USER ubuntu
+# CMD ["/bin/bash", "-l", "-c"]
+# CMD source /home/ubuntu/.bashrc

--- a/docker/aarch64_headless/README.md
+++ b/docker/aarch64_headless/README.md
@@ -1,0 +1,29 @@
+# Docker container for RL training
+
+This directory contains scripts to build and run a docker container for RL training.
+
+## Build
+
+```bash
+cd $REPO/docker/aarch64_headless
+sh build.sh
+```
+
+## Run
+
+### DQN
+
+* Cartpole
+
+  ```bash
+  cd $REPO/docker/aarch64_headless
+  sh run.sh "cargo run --example dqn_cartpole --features='tch'"
+  ```
+
+  * Use a directory not mounted on the host as a cargo target directory,
+    making compile faster on Mac, where access to mounted directories is slow.
+
+    ```bash
+    cd $REPO/docker/aarch64_headless
+    sh run.sh "CARGO_TARGET_DIR=/home/ubuntu/target cargo run --example dqn_cartpole --features='tch'"
+    ```

--- a/docker/aarch64_headless/README.md
+++ b/docker/aarch64_headless/README.md
@@ -1,8 +1,10 @@
-# Docker container for RL training
+# Docker container for training
 
-This directory contains scripts to build and run a docker container for RL training.
+This directory contains scripts to build and run a docker container for training.
 
 ## Build
+
+The following command creates a container image locally, named `border_headless`.
 
 ```bash
 cd $REPO/docker/aarch64_headless
@@ -10,6 +12,10 @@ sh build.sh
 ```
 
 ## Run
+
+The following commands runs a program for training an agent.
+The trained model will be saved in `$REPO/border/examples/model` directory,
+which is mounted in the container.
 
 ### DQN
 

--- a/docker/aarch64_headless/build.sh
+++ b/docker/aarch64_headless/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t border_headless .

--- a/docker/aarch64_headless/run.sh
+++ b/docker/aarch64_headless/run.sh
@@ -1,0 +1,5 @@
+docker run -it --rm \
+    --name border_headless \
+    --shm-size=512m \
+    --volume="$(pwd)/../..:/home/ubuntu/border" \
+    border_headless bash -l -c "$@"


### PR DESCRIPTION
This PR adds Docker scripts and related files for making a Docker container for RL training. There is no changes on the code of the library.

NOTE: Currently tests failed on GitHub, likely due to sdl library installation. It will be fixed in a future PR before merging `dev_0_0_6` into `main`.