### PR TITLE
Add time as tags

### DIFF
--- a/border-mlflow-tracking/Cargo.toml
+++ b/border-mlflow-tracking/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true, features = ["derive"] }
 log = { workspace = true }
 serde_json = { workspace = true }
 flatten-serde-json = "0.1.0"
+chrono = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/border-tch-agent/src/model/base.rs
+++ b/border-tch-agent/src/model/base.rs
@@ -22,6 +22,7 @@ pub trait ModelBase {
 }
 
 /// Neural networks with a single input and a single output.
+#[allow(dead_code)]
 pub trait Model1: ModelBase {
     /// The input of the neural network.
     type Input;
@@ -39,6 +40,7 @@ pub trait Model1: ModelBase {
 }
 
 /// Neural networks with double inputs and a single output.
+#[allow(dead_code)]
 pub trait Model2: ModelBase {
     /// An input of the neural network.
     type Input1;


### PR DESCRIPTION
`mlflow-export-import` can be used to share experiment logs, but this tool will not retain the original timestamp information recorded on the host where the training was performed. This PR will address this by adding tags for the start time, end time and duration of the training.